### PR TITLE
fix: expose getUrlForRedirect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "guzzlehttp/psr7": "^1.0|^2.0"
+        "guzzlehttp/psr7": "^1.0|^2.0",
+        "beta/bx.logger": "^2.0"
     }
 }

--- a/install/files/oauth/openid/index.php
+++ b/install/files/oauth/openid/index.php
@@ -15,6 +15,10 @@ if(isset($_REQUEST["state"]) && is_string($_REQUEST["state"])) {
 
 require_once($_SERVER['DOCUMENT_ROOT']."/bitrix/modules/main/include/prolog_before.php");
 
+while (ob_get_level()) {
+    ob_end_flush();
+}
+
 if(CModule::IncludeModule("socialservices"))
 {
     $statePayload = StateService::getInstance()->getPayload($_REQUEST["state"]);

--- a/lib/socservopenid.php
+++ b/lib/socservopenid.php
@@ -376,9 +376,14 @@ abstract class SocServOpenId extends CSocServAuth
         global $APPLICATION;
         $APPLICATION->RestartBuffer();?>
         <script type="text/javascript">
-            if (window.opener)
-                window.opener.location = '<?=CUtil::JSEscape($redirectUrl)?>';
-            window.close();
+            const url = '<?=CUtil::JSEscape($redirectUrl)?>';
+
+            if (window.opener) {
+                window.opener.location = url;
+                window.close();
+            } else {
+                window.location.href = url;
+            }
         </script>
         <?php
         die();
@@ -407,7 +412,7 @@ abstract class SocServOpenId extends CSocServAuth
         return "BX.util.popup('" . CUtil::JSEscape($url) . "', 460, 420)";
     }
 
-    private function getUrlForRedirect(): string
+    public function getUrlForRedirect(): string
     {
         try {
             return $this->getAuthTransport()->getUrlForRedirect();


### PR DESCRIPTION
Привет! Данные небольшие правки позволят открывать ссылки на SSO и авторизовать пользователей без необходимости открывать отдельные окна. Это расширяет возможности для интеграции единой авторизации в любой Битрикс. И добавил beta/bx.logger в composer, без него возникает ошибка, если не удалять вручную логгирование.